### PR TITLE
Add unbindButton to KeyController

### DIFF
--- a/src/keyboard.js
+++ b/src/keyboard.js
@@ -4,36 +4,60 @@ export class KeyController {
 		this.bindings = [];
 	}
 
-	bindButton(domSelector, keyCode) {
-		const el = typeof domSelector === 'string'
-		? document.querySelector(domSelector)
-		: domSelector;
+        bindButton(domSelector, keyCode) {
+                const el = typeof domSelector === 'string'
+                ? document.querySelector(domSelector)
+                : domSelector;
 
-		if (!el) return;
+                if (!el) return;
 
-		const onStart = (e) => {
-			if (!this.activeKeys.has(keyCode)) {
-				this._fireKey('keydown', keyCode);
-				this.activeKeys.add(keyCode);
-			}
-			e.preventDefault();
-		};
+                const onStart = (e) => {
+                        if (!this.activeKeys.has(keyCode)) {
+                                this._fireKey('keydown', keyCode);
+                                this.activeKeys.add(keyCode);
+                        }
+                        e.preventDefault();
+                };
 
-		const onEnd = (e) => {
-			if (this.activeKeys.has(keyCode)) {
-				this._fireKey('keyup', keyCode);
-				this.activeKeys.delete(keyCode);
-			}
-			e.preventDefault();
-		};
+                const onEnd = (e) => {
+                        if (this.activeKeys.has(keyCode)) {
+                                this._fireKey('keyup', keyCode);
+                                this.activeKeys.delete(keyCode);
+                        }
+                        e.preventDefault();
+                };
 
-		el.addEventListener('touchstart', onStart, { passive: false });
-		el.addEventListener('mousedown', onStart);
-		el.addEventListener('touchend', onEnd, { passive: false });
-		el.addEventListener('mouseup', onEnd);
+                el.addEventListener('touchstart', onStart, { passive: false });
+                el.addEventListener('mousedown', onStart);
+                el.addEventListener('touchend', onEnd, { passive: false });
+                el.addEventListener('mouseup', onEnd);
 
-		this.bindings.push({ el, keyCode });
-	}
+                this.bindings.push({ el, keyCode, onStart, onEnd });
+        }
+
+        unbindButton(domSelector) {
+                const el = typeof domSelector === 'string'
+                ? document.querySelector(domSelector)
+                : domSelector;
+
+                if (!el) return;
+
+                this.bindings = this.bindings.filter((binding) => {
+                        if (binding.el !== el) return true;
+
+                        el.removeEventListener('touchstart', binding.onStart, { passive: false });
+                        el.removeEventListener('mousedown', binding.onStart);
+                        el.removeEventListener('touchend', binding.onEnd, { passive: false });
+                        el.removeEventListener('mouseup', binding.onEnd);
+
+                        if (this.activeKeys.has(binding.keyCode)) {
+                                this._fireKey('keyup', binding.keyCode);
+                                this.activeKeys.delete(binding.keyCode);
+                        }
+
+                        return false;
+                });
+        }
 
 	_fireKey(type, code) {
 		const evt = new KeyboardEvent(type, {


### PR DESCRIPTION
## Summary
- Track event listeners when binding keyboard controls to DOM elements
- Implement `unbindButton` to detach listeners and clean up active keys

## Testing
- `npm run build` *(fails: rollup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689568e1aff4832c9d75a90f3f283135