### PR TITLE
fix: properly unregister touch handlers

### DIFF
--- a/src/canvasView.js
+++ b/src/canvasView.js
@@ -109,9 +109,13 @@ export class CanvasViewControl {
 
         destroy() {
                 if (!this.canvas) return;
-                this.canvas.removeEventListener("touchstart", this._touchStartHandler);
-                this.canvas.removeEventListener("touchmove", this._touchMoveHandler);
-                this.canvas.removeEventListener("touchend", this._touchEndHandler);
+
+                this.canvas.removeEventListener('touchstart', this._onStart);
+                this.canvas.removeEventListener('touchmove', this._onMove);
+                this.canvas.removeEventListener('touchend', this._onEnd);
+
+                this._onStart = this._onMove = this._onEnd = null;
+
                 if (this._applyBodyStyle) {
                         const body = document.body;
                         if (this._prevBodyStyle) {


### PR DESCRIPTION
## Summary
- ensure touch listeners use stored bound handlers
- clear handler references on destroy to aid GC

## Testing
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree / 403 Forbidden)*
- `npm run build` *(fails: rollup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2d3afe8832ca49c469ee3ab94c9